### PR TITLE
Fix missing annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <dependencies>
     <dependency>
       <groupId>io.cucumber</groupId>
-      <artifactId>cucumber-java8</artifactId>
+      <artifactId>cucumber-java</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -57,7 +57,7 @@
     <dependencies>
       <dependency>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-java8</artifactId>
+        <artifactId>cucumber-java</artifactId>
         <version>${cucumber.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
`cucumber-java8` no longer contain annotations such as `@Given`.
Instead it is now available in `cucumber-java`.

Fixes gh-13.